### PR TITLE
Makefile what-the-fuckery workaround

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 DESTDIR := /usr/local
 CFLAGS := -ggdb -I./include -I/usr/include -DGPROF -pthread -O3 -Wall \
-          -Wextra -fPIC -pedantic -fgnu-tm
-LDFLAGS := -g -pthread -lhttp_parser -llmdb -fgnu-tm
+          -Wextra -fPIC -pedantic
+LDFLAGS := -g -pthread -lhttp_parser
 
 ifeq ($(CC),gcc)
 	CFLAGS += -std=gnu11
@@ -15,16 +15,26 @@ OUT := out
 SOURCE := buffer.c http.c list.c pool.c server.c timers.c
 OBJS := $(addprefix $(OUT)/,$(patsubst %.c,%.o,$(SOURCE)))
 
-EXECUTABLE := uvb-server
+.PHONY: lmdb
+lmdb: uvb-server-lmdb
+
+.PHONY: tm
+tm: uvb-server-tm
 
 .PHONY: all
-all: uvb-server-lmdb
+all: lmdb tm
 
 $(OUT)/%.o: src/%.c Makefile
 	$(CC) -c $(CFLAGS) -o $@ $<
 
-uvb-server-%: $(OUT)/%_counter.o $(OBJS) 
-	$(CC) $(LDFLAGS) -o $@ $< $(OBJS)
+$(OUT)/tm_counter.o: src/tm_counter.c Makefile
+	$(CC) -c $(CFLAGS) -fgnu-tm -o $@ $<
+
+uvb-server-lmdb: out/lmdb_counter.o $(OBJS) 
+	$(CC) $(LDFLAGS) -llmdb -o $@ $(OBJS) out/lmdb_counter.o
+
+uvb-server-tm: out/tm_counter.o $(OBJS) 
+	$(CC) $(LDFLAGS) -fgnu-tm -o $@ $(OBJS) out/tm_counter.o
 
 .PHONY: install
 install:
@@ -32,7 +42,7 @@ install:
 
 .PHONY: clean
 clean:
-	$(RM) -rf $(OUT) $(EXECUTABLE) counters.db names.db
+	$(RM) -rf $(OUT) uvb-server-{lmdb,tm} counters.db names.db
 	mkdir $(OUT)
 
 .PHONY: uninstall


### PR DESCRIPTION
Apparently wildcard-rules sometimes auto-delete intermediates. What the fuck?

Also flags are handled better now.